### PR TITLE
feat: auto-add scanned barcode items to cart (toggleable)

### DIFF
--- a/posawesome/posawesome/doctype/pos_settings_panel/pos_settings_panel.json
+++ b/posawesome/posawesome/doctype/pos_settings_panel/pos_settings_panel.json
@@ -11,6 +11,7 @@
   "country_code",
   "column_break_1mdhc",
   "use_outstanding_amount_in_sales_invoice",
+  "enable_barcode_auto_add",
   "customer_defaults_section",
   "default_customer_group",
   "default_customer_territory",
@@ -68,12 +69,18 @@
    "fieldname": "exact_payment",
    "fieldtype": "Check",
    "label": "Exact Payment"
+  },
+  {
+   "default": "1",
+   "fieldname": "enable_barcode_auto_add",
+   "fieldtype": "Check",
+   "label": "Enable Barcode Auto-Add"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-25 12:38:56.060726",
+ "modified": "2025-08-27 05:14:33.928907",
  "modified_by": "Administrator",
  "module": "POSAwesome",
  "name": "POS Settings Panel",

--- a/posawesome/posawesome/doctype/pos_settings_panel/pos_settings_panel.json
+++ b/posawesome/posawesome/doctype/pos_settings_panel/pos_settings_panel.json
@@ -12,6 +12,7 @@
   "column_break_1mdhc",
   "use_outstanding_amount_in_sales_invoice",
   "enable_barcode_auto_add",
+  "allow_edit_qty_without_expand",
   "customer_defaults_section",
   "default_customer_group",
   "default_customer_territory",
@@ -75,12 +76,18 @@
    "fieldname": "enable_barcode_auto_add",
    "fieldtype": "Check",
    "label": "Enable Barcode Auto-Add"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_edit_qty_without_expand",
+   "fieldtype": "Check",
+   "label": "Allow Edit QTY without Expand"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-27 05:14:33.928907",
+ "modified": "2025-08-29 08:10:14.338748",
  "modified_by": "Administrator",
  "module": "POSAwesome",
  "name": "POS Settings Panel",

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -218,7 +218,25 @@
             @update:expanded="handleExpandedUpdate">
             <!-- Quantity Column Template -->
             <template v-slot:item.qty="{ item }">
-              {{ formatFloat(item.qty) }}
+              <div v-if="pos_settings_panel && pos_settings_panel.allow_edit_qty_without_expand">
+                <v-text-field
+                  :model-value="formatFloat(item.qty)"
+                  variant="plain"
+                  density="compact"
+                  hide-details
+                  single-line
+                  type="number"
+                  :min="invoiceType === 'Return' ? null : 0"
+                  :step="1"
+                  @update:model-value="updateQtyInline(item, $event)"
+                  :rules="[isNumber]"
+                  :disabled="!!item.posa_is_replace"
+                  @click.stop=""
+                ></v-text-field>
+              </div>
+              <div v-else>
+                {{ formatFloat(item.qty) }}
+              </div>
             </template>
             <!-- Rate Column Template with Currency Symbol -->
             <template v-slot:item.rate="{ item }">
@@ -841,6 +859,7 @@ export default {
     return {
       // POS profile settings
       pos_profile: "",
+      pos_settings_panel: "",
       pos_opening_shift: "",
       stock_settings: "",
       invoice_doc: { posa_notes: ""},
@@ -4852,12 +4871,37 @@ export default {
         this.update_discount_umount();
       }
     },
+    updateQtyInline(item, value) {
+      let parsedValue = parseFloat(value);
+      if (isNaN(parsedValue)) {
+        parsedValue = 0;
+      }
+      
+      if (this.invoiceType === "Return" && parsedValue > 0) {
+        parsedValue = -Math.abs(parsedValue);
+      }
+      
+      if (this.invoiceType !== "Return" && parsedValue < 0) {
+        parsedValue = 0;
+      }
+      
+      item.qty = parsedValue;
+      
+      this.calc_stock_qty(item, item.qty);
+      
+      if (item.qty === 0) {
+        this.remove_item(item);
+      }
+      
+      this.$forceUpdate();
+    },
   },
 
   mounted() {
     // Register event listeners for POS profile, items, customer, offers, etc.
     this.eventBus.on("register_pos_profile", (data) => {
       this.pos_profile = data.pos_profile;
+      this.pos_settings_panel = data.pos_settings_panel;
       this.customer = data.pos_profile.customer;
       this.pos_opening_shift = data.pos_opening_shift;
       this.stock_settings = data.stock_settings;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -276,6 +276,7 @@ export default {
   mixins: [format],
   data: () => ({
     pos_profile: "",
+    pos_settings_panel: "",
     flags: {},
     items_view: "list",
     item_group: "ALL",
@@ -596,6 +597,9 @@ export default {
       }
       if (match) {
         this.add_item(new_item);
+        this.search = null;
+        this.first_search = null;
+        this.debounce_search = null;
         this.flags.serial_no = null;
         this.flags.batch_no = null;
         this.qty = 1;
@@ -813,7 +817,9 @@ export default {
         });
         frappe.utils.play_sound("error");
       } else {
-        this.enter_event();
+        if(this.pos_settings_panel && this.pos_settings_panel.enable_barcode_auto_add) {
+          this.enter_event();
+        }
       }
     },
     setFastItemGroupFilter(event, groupName) {
@@ -1172,6 +1178,7 @@ export default {
     this.$nextTick(function () { });
     this.eventBus.on("register_pos_profile", (data) => {
       this.pos_profile = data.pos_profile;
+      this.pos_settings_panel = data.pos_settings_panel;
       this.selected_currency = this.pos_profile.currency;
       this.get_items();
       this.get_items_groups();


### PR DESCRIPTION
- Add a new field 'enable_barcode_auto_add' to POS Settings Panel single-doctype to enable/disable the feature.
- Auto-add matched item to the cart (increment qty on duplicate scans).
- Fallback to normal search when no match found.